### PR TITLE
Feat：Add splash screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,7 +1342,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1370,7 +1369,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1544,7 +1542,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/Values.ts
+++ b/src/Values.ts
@@ -68,8 +68,8 @@ export class McmodderValues {
   static readonly mcmodderVersion = GM_info.script.version || "Unknown";
   static readonly MAX_REQUEST_COUNT = 10000;
   static readonly MAX_RECIPE_LENGTH = 100;
-  static readonly headerContainerHeight = $(".top-main, .header-container, #top").get(0)?.getBoundingClientRect()?.height || 50; // 50
-  static readonly errorMessage = typeof PublicLangData != "undefined" ? PublicLangData.warning.inform : {};
+  static get headerContainerHeight() { return $(".top-main, .header-container, #top").get(0)?.getBoundingClientRect()?.height || 50; } // 50
+  static get errorMessage() { return typeof PublicLangData != "undefined" ? PublicLangData.warning.inform : {}; }
   
   static readonly iconMap = {
     "后台管理": "fa fa-university",

--- a/src/loader/StyleLoader.ts
+++ b/src/loader/StyleLoader.ts
@@ -42,14 +42,14 @@ export class StyleLoader {
   }
 
   static async run(parent: Mcmodder) {
-    const module = import.meta.glob('../css/*.css', { query: "?raw" });
-    const baseCss = (await module["../css/base.css"]() as any).default as string;
-    const mcmodderUICss = (await module["../css/mcmodderUI.css"]() as any).default as string;
-    const aprilFoolsCss = (await module["../css/aprilFools.css"]() as any).default as string;
-    const tableThemeColorCss = (await module["../css/tableThemeColor.css"]() as any).default as string;
-    const tableLeftAlignCss = (await module["../css/tableLeftAlign.css"]() as any).default as string;
-    const tabSelectorInfoCss = (await module["../css/tabSelectorInfo.css"]() as any).default as string;
-    const splitScreenOnVerifyCss = (await module["../css/splitScreenOnVerify.css"]() as any).default as string;
+    const module = import.meta.glob('../css/*.css', { query: "?raw", eager: true });
+    const baseCss = (module["../css/base.css"] as any).default as string;
+    const mcmodderUICss = (module["../css/mcmodderUI.css"] as any).default as string;
+    const aprilFoolsCss = (module["../css/aprilFools.css"] as any).default as string;
+    const tableThemeColorCss = (module["../css/tableThemeColor.css"] as any).default as string;
+    const tableLeftAlignCss = (module["../css/tableLeftAlign.css"] as any).default as string;
+    const tabSelectorInfoCss = (module["../css/tabSelectorInfo.css"] as any).default as string;
+    const splitScreenOnVerifyCss = (module["../css/splitScreenOnVerify.css"] as any).default as string;
 
     const basePalette: McmodderPalette = {
       "background": "#fff",
@@ -240,5 +240,10 @@ export class StyleLoader {
     McmodderUtils.addStyle(style);
 
     parent.updateNightMode();
+    const splashScreen = document.getElementById("mcmodder-splash-screen");
+    if (splashScreen) {
+      splashScreen.textContent = `body { animation: mcmodder-fadein .3s ease forwards; } @keyframes mcmodder-fadein { from { opacity: 0; } to { opacity: 1; } }`;
+      setTimeout(() => splashScreen.remove(), 300);
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,28 @@
+import { GM_getValue } from "$";
 import { Mcmodder } from './Mcmodder';
 
 (() => {
-  return new Mcmodder;
+  let nightMode = false;
+  try {
+    const settings = JSON.parse(GM_getValue("mcmodderSettings") || "{}");
+    nightMode = !!settings.nightMode;
+  } catch (e) {}
+  const splashStyle = document.createElement("style");
+  //遮罩，防止显示百科原网页闪烁
+  splashStyle.id = "mcmodder-splash-screen";
+  splashStyle.textContent = `html { background: ${nightMode ? "#000" : "#fff"} !important; } body { visibility: hidden !important; }`;
+  document.documentElement.appendChild(splashStyle);
+  const init = () => new Mcmodder;
+  const tryInit = () => {
+    if (typeof jQuery !== "undefined") {
+      init();
+    } else {
+      window.addEventListener("load", init, { once: true });
+    }
+  };
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", tryInit, { once: true });
+  } else {
+    tryInit();
+  }
 })();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         license: "AGPL-3.0",
         icon: 'https://www.mcmod.cn/static/public/images/favicon.ico',
         namespace: 'http://www.mcmod.cn/',
-        "run-at": 'document-end',
+        "run-at": 'document-start',
         match: ['https://*.mcmod.cn/*'],
         exclude: [
           "https://api.mcmod.cn/*",


### PR DESCRIPTION
添加了一个纯色启动画面，将脚本加载时间改为document-start，在百科网页加载前加载脚本，避免了闪现原网页。
主要是深色模式闪烁有点难受（）突然白一下（）
对比
Before:




https://github.com/user-attachments/assets/10a7d8d5-98bf-4eb8-b94d-471f8f1b830e


After:

https://github.com/user-attachments/assets/63e25cc9-1ec4-4217-b932-0243efea902c

