### PR TITLE
[CI] Add auto release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,3 +26,16 @@ jobs:
         with:
           name: dist
           path: dist/
+  release:
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, '[release]')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create v${{ env.VERSION }} --generate-notes


### PR DESCRIPTION
往github action workflow里添加了自动release功能，commit head包含[release]就会从package.json获取版本自动发release