### PR TITLE
修复在深色模式下的短评编辑器字体颜色问题

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -2163,6 +2163,10 @@ html.dark .edui-default .edui-tablepicker .edui-pickarea,
 html.dark .edui-default .edui-tablepicker .edui-pickarea .edui-overlay {
   filter: invert(80%);
 }
+html.dark .common-comment-block textarea,
+html.dark .common-comment-block input {
+  color: var(--mcmodder-color-text) !important;
+}
 html .edui-default .edui-editor-toolbarboxouter,
 .banner .m_menu .m_center,
 .banner .m_menu .banner .m_menu {


### PR DESCRIPTION
就加了个简单的样式，让短评编辑器内的字体颜色随深色模式变化
<img width="747" height="301" alt="屏幕截图 2026-05-11 113542" src="https://github.com/user-attachments/assets/72e58843-6740-4cfe-a0df-aec9f55b1140" />
<img width="1826" height="247" alt="屏幕截图 2026-05-11 112524" src="https://github.com/user-attachments/assets/2cb37dd7-6699-4821-a396-df8fe85f254b" />
