### PR TITLE
添加无限制留言板配套配置回复限制绕过

### DIFF
--- a/src/Mcmodder.ts
+++ b/src/Mcmodder.ts
@@ -515,12 +515,69 @@ export class Mcmodder {
     this.isNightMode = !this.isNightMode;
   }
 
+  private initAjaxBypass() {
+    const originalAjax = $.ajax;
+    if (typeof originalAjax !== "function") return;
+
+    const self = this;
+    $.ajax = function (urlOrSettings: any, settings?: any) {
+      const ajaxSettings = typeof urlOrSettings === "object" ? urlOrSettings : settings;
+      if (ajaxSettings && self.utils.getConfig("bypassReplyLimit") && (window as any).bypassNextReply) {
+        const url = typeof urlOrSettings === "string" ? urlOrSettings : ajaxSettings.url;
+        if (url && (url.includes("/action/doComment/") || url.includes("/action/doComment"))) {
+          const data = ajaxSettings.data;
+          let targetContainerId = self.utils.getConfig("bypassReplyContainerId")?.trim();
+          if (!targetContainerId) {
+            targetContainerId = self.currentUID ? String(self.currentUID) : "";
+          }
+
+          if (targetContainerId && targetContainerId !== "0") {
+            try {
+              if (typeof data === "string") {
+                const params = new URLSearchParams(data);
+                const dataJson = params.get("data");
+                if (dataJson) {
+                  const payloadObj = JSON.parse(dataJson);
+                  if (payloadObj && payloadObj.todo === "submit" && payloadObj.type === "center" && payloadObj.reply) {
+                    payloadObj.container = targetContainerId;
+                    params.set("data", JSON.stringify(payloadObj));
+                    ajaxSettings.data = params.toString();
+                  }
+                } else {
+                  const payloadObj = JSON.parse(data);
+                  if (payloadObj && payloadObj.todo === "submit" && payloadObj.type === "center" && payloadObj.reply) {
+                    payloadObj.container = targetContainerId;
+                    ajaxSettings.data = JSON.stringify(payloadObj);
+                  }
+                }
+              } else if (typeof data === "object" && data !== null) {
+                if (typeof data.data === "string") {
+                  const payloadObj = JSON.parse(data.data);
+                  if (payloadObj && payloadObj.todo === "submit" && payloadObj.type === "center" && payloadObj.reply) {
+                    payloadObj.container = targetContainerId;
+                    data.data = JSON.stringify(payloadObj);
+                  }
+                } else if (data.todo === "submit" && data.type === "center" && data.reply) {
+                  data.container = targetContainerId;
+                }
+              }
+            } catch (e) {
+              // ignore
+            }
+          }
+        }
+      }
+      return originalAjax.apply(this, arguments as any);
+    };
+  }
+
   copyright() {
     $(".copyleft").last().append(`<br>☆ MCMODDER v${McmodderValues.mcmodderVersion} ☆ ——MC百科编审辅助工具`);
     $(".sidebar-plan .space").last().append(`<br>mcmodder-v${McmodderValues.mcmodderVersion}`);
   }
 
   main() {
+    this.initAjaxBypass();
     if (this.utils.getConfig("forceV4") && (this.href === `${ this.hostname }/`)) {
       window.location.href = `${ this.hostname }/v4/`;
     }

--- a/src/init/CommentInit.ts
+++ b/src/init/CommentInit.ts
@@ -52,6 +52,7 @@ export class CommentInit extends McmodderInit {
   }
 
   private readonly commentObserver = new MutationObserver(mutationList => {
+    this.addBypassButtons();
     for (let mutation of mutationList) {
       const commentFloor = $(mutation.target);
       const className = commentFloor.prop("class");
@@ -194,6 +195,23 @@ export class CommentInit extends McmodderInit {
     }
   }
 
+  private addBypassButtons() {
+    if (!this.parent.utils.getConfig("bypassReplyLimit")) return;
+    $(".comment-reply-submit:not(.mcmodder-processed)").each((_, btn) => {
+      const $btn = $(btn);
+      $btn.addClass("mcmodder-processed");
+      const $bypassBtn = $(`<input class="btn btn-sm btn-warning comment-reply-submit-bypass" value="绕过回复" type="button" style="margin-left: 5px; vertical-align: bottom;">`);
+      $btn.after($bypassBtn);
+      $bypassBtn.click(() => {
+        (window as any).bypassNextReply = true;
+        $btn.click();
+        setTimeout(() => {
+          (window as any).bypassNextReply = false;
+        }, 0);
+      });
+    });
+  }
+
   run() {
     if (this.parent.utils.getConfig("commentExpandHeight")) {
       let commentHeight = this.parent.utils.getConfig("commentExpandHeight") || "300";
@@ -213,5 +231,6 @@ export class CommentInit extends McmodderInit {
       childList: true,
       subtree: true
     });
+    this.addBypassButtons();
   }
 }

--- a/src/loader/ConfigLoader.ts
+++ b/src/loader/ConfigLoader.ts
@@ -88,6 +88,8 @@ export class ConfigLoader {
     .addCheckboxConfig("expCalculator", "经验计算器", "决定是否在个人等级页显示当前等级相关数据。")
     .addCheckboxConfig("freezeAdvancements", "冻结进度", "使窗口右上角弹出的进度框不再自动消失。快截图留念吧！")
     .addCheckboxConfig("unlockComment", "无限制留言板", "强行显示目标用户留言板，或是模组/作者的短评区，即使其已受天体运动影响而关闭。请勿滥用，除非你想见到重生亲手把这个特性毙掉。")
+    .addCheckboxConfig("bypassReplyLimit", "回复限制绕过", "绕过原本不可回复短评的界面，使短评能显示在已关闭回复功能的界面上。")
+    .addTextConfig("bypassReplyContainerId", "回复绕过目标ID", "指定绕过后的目标 container ID，留空则默认使用当前登录用户的UID。")
     .addCheckboxConfig("ignoreEmptyLine", "忽略短评空白行", "隐藏短评正文中的空白行。")
     .addCheckboxConfig("replyLink", "楼中楼跳转链接", "轻触短评楼中楼里出现的链接来快捷访问。该功能可能无法正确识别后文紧随其他文字的链接。")
     .addCheckboxConfig("missileAlert", "核弹警告", "当短评长度超过特定值时，弹出核弹警告。")


### PR DESCRIPTION
回复短评加了个绕过回复按钮，会修改回复包Payload的ContainerId到可回复的界面但不改动CID以实现绕过回复权限，默认禁用。
（希望不会有人滥用...）
<img width="747" height="168" alt="图片" src="https://github.com/user-attachments/assets/1695d4fc-10ea-43b9-8d98-44746de260f7" />
