### PR TITLE
修复下拉栏设置修改后不保存的问题

### DIFF
--- a/src/init/center/CenterSettingInit.ts
+++ b/src/init/center/CenterSettingInit.ts
@@ -96,6 +96,12 @@ export class CenterSettingInit extends CenterBaseInit {
       function () {
         setSetting($(this).attr('data-todo'), $(this).val().trim());
       }
+    ).on(
+      'change',
+      '.center-block[data-menu-frame!=9] .center-setting-block .selectpicker',
+      function () {
+        setSetting($(this).attr('data-todo'), $(this).val());
+      }
     );
 
     // 相关链接预览图尺寸调整


### PR DESCRIPTION
很简单的bug，解绑后的selectpicker没有进行重新绑定（