### PR TITLE
添加基于Supabase的标语投稿/抓取云端标语显示功能

### DIFF
--- a/src/Mcmodder.ts
+++ b/src/Mcmodder.ts
@@ -68,6 +68,8 @@ export class Mcmodder {
     this.isMobileClient = McmodderUtils.isMobileClient();
     const headerUserName = $(".header-user-name a, .name.top-username a, .profilebox").first();
     this.currentUsername = headerUserName.text() || "";
+    const win = typeof (globalThis as any).unsafeWindow !== 'undefined' ? (globalThis as any).unsafeWindow : window;
+    (win as any).__mcmodder_username__ = this.currentUsername;
     this.currentUID = Number(headerUserName.attr("href")?.split("//center.mcmod.cn/")[1]?.split("/")[0]) || 0;
     this.ueditorFrame = [];
     this.href = window.location.href;
@@ -409,9 +411,21 @@ export class Mcmodder {
   }
 
   async trackSplash() {
-    let splashText = "";
-    if (this.href === `${ this.hostname }/`) splashText = $(".ooops .text").first().text();
-    else if (this.href === `${ this.hostname }/v4/`) splashText = $(".splash span").first().text();
+    const win = typeof (globalThis as any).unsafeWindow !== 'undefined' ? (globalThis as any).unsafeWindow : window;
+    if ((win as any).__mcmodder_splash_tracked__) return;
+    if ((win as any).__mcmodder_custom_splash__) {
+      (win as any).__mcmodder_splash_tracked__ = true;
+      return;
+    }
+
+    let splashText = (win as any).__mcmodder_orig_splash__ || "";
+    if (!splashText) {
+      if (this.href === `${ this.hostname }/`) splashText = $(".ooops .text").first().text();
+      else if (this.href === `${ this.hostname }/v4/`) splashText = $(".splash span").first().text();
+    }
+    if (!splashText) return;
+
+    (win as any).__mcmodder_splash_tracked__ = true;
     splashText = splashText.replace(this.currentUsername || "百科酱", "%s");
     let splashes: string[] = GM_getValue("mcmodderSplashList_v2")?.split("\n") || [], flag = 0, index = -1;
     splashes.forEach((e, i) => {
@@ -580,11 +594,20 @@ export class Mcmodder {
     }
 
     // 闪烁标语追踪器
-    if (this.utils.getConfig("enableSplashTracker") &&
-      (this.href === `${ this.hostname }/` ||
+    if ((this.href === `${ this.hostname }/` ||
         this.href === `${ this.hostname }/v4/`) ||
       this.href === "https://play.mcmod.cn/") {
+      this.trackSplash();
       setTimeout(() => this.trackSplash(), 3e2);
+    }
+
+    // 后台抓取并更新云端自定义标语列表缓存
+    if (this.utils.getConfig("useSupabase") && this.utils.getConfig("fetchCustomSplashes")) {
+      this.supabaseUtils.fetchCustomSplashes().then(list => {
+        if (list && Array.isArray(list)) {
+          GM_setValue("mcmodderCustomSplashes", JSON.stringify(list));
+        }
+      }).catch(() => {});
     }
     if (this.utils.getConfig("splashStyle") === 1 &&
       (this.href === `${ this.hostname }/` ||

--- a/src/init/center/CenterSettingInit.ts
+++ b/src/init/center/CenterSettingInit.ts
@@ -432,8 +432,48 @@ export class CenterSettingInit extends CenterBaseInit {
     });
 
     $(`<div class="center-setting-block" style="margin-top: 2em;">
+      <h4 style="margin-bottom: 0.5em; font-weight: bold;">投稿自定义闪烁标语</h4>
+      <p class="text-muted" style="margin-bottom: 0.8em; font-size: 13px;">已登录用户可投稿标语至云端。投稿需经脚本管理员审核过审后方可被其它脚本用户抓取显示。</p>
+      <div class="setting-item" style="display: flex; gap: 8px; align-items: center;">
+        <input type="text" id="mcmodder-custom-splash-input" class="form-control" placeholder="输入自定义闪烁标语内容..." style="max-width: 400px; display: inline-block;">
+        <button class="btn btn-primary" id="mcmodder-custom-splash-submit">提交投稿</button>
+      </div>
+    </div>`).appendTo(mcmodderSettingMenu)
+    .find("#mcmodder-custom-splash-submit")
+    .click(async e => {
+      const button = $(e.currentTarget);
+      const input = $("#mcmodder-custom-splash-input");
+      const content = String(input.val() || "").trim();
+
+      if (!content) {
+        McmodderUtils.commonMsg("标语内容不能为空！", false);
+        return;
+      }
+
+      if (!this.getParent().currentUID) {
+        McmodderUtils.commonMsg("请先登录 MC百科 账号后再发起投稿！", false);
+        return;
+      }
+
+      const authKey = this.getParent().utils.getProfile("auth_key");
+      if (!authKey) {
+        McmodderUtils.commonMsg("未获取到登录校验 Key，请重新登录！", false);
+        return;
+      }
+
+      McmodderUtils.setButtonLoadingState(button);
+      const res = await this.getParent().supabaseUtils.uploadCustomSplash(content, authKey);
+      McmodderUtils.cancelButtonLoadingState(button);
+
+      if (res && res.message) {
+        McmodderUtils.commonMsg(res.message);
+        input.val("");
+      }
+    });
+
+    $(`<div class="center-setting-block" style="margin-top: 2em;">
       <div class="setting-item">
-        <button class="btn">清除当前所有计划任务</btn>
+        <button class="btn">清除当前所有计划任务</button>
       </div>
       <p class="text-muted">这在某些时候很有用——也许吧？</p>
     </div>`).appendTo(mcmodderSettingMenu)

--- a/src/loader/ConfigLoader.ts
+++ b/src/loader/ConfigLoader.ts
@@ -10,6 +10,9 @@ export class ConfigLoader {
     .addColorpickerConfig("themeColor3", "主题样式警告配色", "主题样式警告配色。", "#ff3030")
     .addCheckboxConfig("autoCheckUpdate", "自动检查更新", "每隔一段时间自动检查更新，并在有新更新可用时提醒。", true)
     .addCheckboxConfig("useSupabase", "启用云端服务", "是否启用 Mcmodder 云端服务与功能。相关服务由 Supabase 驱动。若禁用此项，所有依赖云端服务的功能都不会运作。")
+    .addCheckboxConfig("fetchCustomSplashes", "抓取云端闪烁标语", "是否抓取与显示用户投稿并审核通过的 Supabase 云端闪烁标语。")
+    .addNumberConfig("customSplashRate", "云端标语替换概率 (%)", "设置进入主页时使用云端自定义闪烁标语替换 MC百科 官方默认标语的概率。", 
+      50, [0, 100])
     .addCheckboxConfig("supabaseSplash", "云端闪烁标语同步", "[需要用户认证] 启用后，脚本会将主页记录的闪烁标语自动上传到云端的闪烁标语库，同时记录标语贡献者。")
     .addCheckboxConfig("supabaseByteChart", "云端字数统计数据", "启用后，脚本会从云端读取贡献榜数据，用于显示个人主页的字数统计图表。")
     .addCheckboxConfig("moveAds", "广告优化", "将百科的部分广告移动到不影响浏览体验的位置。（本脚本不会主动隐藏或屏蔽广告，若欲屏蔽请自行安装广告屏蔽插件）")

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,74 @@ import { Mcmodder } from './Mcmodder';
 import bbsCss from './css/bbs.css?raw';
 
 (() => {
+  try {
+    const isHomePage = location.hostname.includes("mcmod.cn") && 
+      (location.pathname === "/" || location.pathname === "/v4/" || location.pathname === "/index.html");
+
+    if (isHomePage) {
+      const settings = JSON.parse(GM_getValue("mcmodderSettings") || "{}");
+      const useSupabase = settings.useSupabase !== false;
+      const fetchCustom = settings.fetchCustomSplashes !== false;
+      const rate = typeof settings.customSplashRate === "number" ? settings.customSplashRate : 50;
+
+      if (useSupabase && fetchCustom && Math.random() * 100 < rate) {
+        const cached = GM_getValue("mcmodderCustomSplashes");
+        let splashList: any[] = [];
+        if (cached) {
+          try { splashList = JSON.parse(cached); } catch (_e) {}
+        }
+        if (Array.isArray(splashList) && splashList.length > 0) {
+          const item = splashList[Math.floor(Math.random() * splashList.length)];
+          if (item && item.content) {
+            const targetWin = typeof (globalThis as any).unsafeWindow !== 'undefined' ? (globalThis as any).unsafeWindow : window;
+            (targetWin as any).__mcmodder_custom_splash__ = item.content;
+
+            const applyConsoleOverride = () => {
+              if ((targetWin as any).__mcmodder_console_patched__) return;
+              const origConsoleLog = targetWin.console.log;
+              if (typeof origConsoleLog !== 'function') return;
+
+              (targetWin as any).__mcmodder_console_patched__ = true;
+              targetWin.console.log = function (...args: any[]) {
+                if (args.length >= 1 && typeof args[0] === 'string' && args[0].includes('%c')) {
+                  return origConsoleLog.apply(targetWin.console, [`%c ${item.content}`, args[1] || 'color:#6699FF;']);
+                }
+                return origConsoleLog.apply(targetWin.console, args);
+              };
+            };
+
+            applyConsoleOverride();
+            document.addEventListener('DOMContentLoaded', applyConsoleOverride);
+            window.addEventListener('load', applyConsoleOverride);
+
+            const observer = new MutationObserver(() => {
+              const ooops = document.querySelector(".ooops");
+              const splash = document.querySelector(".splash span");
+
+              if (ooops) {
+                const textEl = ooops.querySelector(".text");
+                const shadowEl = ooops.querySelector(".shadow");
+                if (textEl && textEl.textContent) {
+                  textEl.textContent = item.content;
+                  if (shadowEl) shadowEl.textContent = item.content;
+                  observer.disconnect();
+                }
+              } else if (splash && splash.textContent) {
+                splash.textContent = item.content;
+                observer.disconnect();
+              }
+            });
+
+            observer.observe(document.documentElement, {
+              childList: true,
+              subtree: true
+            });
+          }
+        }
+      }
+    }
+  } catch (_e) {}
+
   let nightMode = false;
   try {
     const settings = JSON.parse(GM_getValue("mcmodderSettings") || "{}");

--- a/src/supabase/SupabaseUtils.ts
+++ b/src/supabase/SupabaseUtils.ts
@@ -1,6 +1,6 @@
 import { createClient, FunctionInvokeOptions, SupabaseClient } from '@supabase/supabase-js';
 import { Mcmodder } from '../Mcmodder';
-import { SupabaseErrorResponse } from '../types';
+import { SupabaseCustomSplash, SupabaseErrorResponse, SupabaseGetCustomSplashesResponse, SupabaseUploadSplashResponse } from '../types';
 import { McmodderUtils } from '../Utils';
 
 export class SupabaseUtils {
@@ -64,5 +64,22 @@ export class SupabaseUtils {
       return;
     }
     return data as SupabaseSuccessfulResponse;
+  }
+
+  async uploadCustomSplash(content: string, authKey: string) {
+    return await this.invoke<SupabaseUploadSplashResponse>(
+      "upload-splash",
+      {
+        body: {
+          auth_key: authKey,
+          content: content
+        }
+      }
+    );
+  }
+
+  async fetchCustomSplashes(): Promise<SupabaseCustomSplash[] | undefined> {
+    const res = await this.invoke<SupabaseGetCustomSplashesResponse>("get-custom-splashes");
+    return res?.splashes;
   }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,8 @@
 import { GmXmlhttpRequestOption, GmXmlhttpRequestType } from "$";
 import { McmodderPermission } from "./config/ConfigUtils";
 
+declare const unsafeWindow: any;
+
 export interface RGB {
   readonly r: number;
   readonly g: number;
@@ -565,4 +567,22 @@ export interface SupabaseSyncSettingsResponse {
   mcmodder_settings?: string,
   user_profile?: string,
   template_list?: string
+}
+
+export interface SupabaseCustomSplash {
+  id?: number;
+  content: string;
+  author_id?: number;
+  author_name?: string;
+}
+
+export interface SupabaseUploadSplashResponse {
+  message?: string;
+  error?: string;
+  data?: any;
+}
+
+export interface SupabaseGetCustomSplashesResponse {
+  splashes?: SupabaseCustomSplash[];
+  error?: string;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
           "https://www.mcmod.cn/item/aspects/*"
         ],
         grant: [
+          'unsafeWindow',
           'GM_cookie',
           'GM_registerMenuCommand',
           'GM_openInTab',


### PR DESCRIPTION
添加了闪烁标语投稿功能，在启用supabase相关功能时可以投稿标语到数据库，经数据库审核后如果开启了启用云端标语就会抓取云端标语在主界面显示。
<img width="901" height="333" alt="图片" src="https://github.com/user-attachments/assets/5ecade4c-8eed-4321-9179-05c97849b300" />
<img width="934" height="198" alt="图片" src="https://github.com/user-attachments/assets/e54e8019-0203-4574-9466-fd5a44bf7ce7" />
